### PR TITLE
Docs: Add missing parenthesis in code example

### DIFF
--- a/docs/tests-pytest-intro.rst
+++ b/docs/tests-pytest-intro.rst
@@ -294,7 +294,7 @@ You can achieve a similar effect with the ``@given`` decorator to automatically 
 
     from brownie.test import given, strategy
 
-    @given(amount=strategy('uint', max_value=1000)
+    @given(amount=strategy('uint', max_value=1000))
     def test_transferFrom_reverts(token, accounts, amount):
         token.approve(accounts[1], amount, {'from': accounts[0]})
         assert token.allowance(accounts[0], accounts[1]) == amount


### PR DESCRIPTION
### What I did

Add missing `)` to a code snippet in docs as currently the example code does not work.
